### PR TITLE
Changed tofCam660 UDP interface to allow reuse of same address since …

### DIFF
--- a/src/epc/tofCam660/interface.py
+++ b/src/epc/tofCam660/interface.py
@@ -111,6 +111,7 @@ class UdpInterface:
         self.data = bytearray()
         self.index = 0
         self.udpSocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.udpSocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.udpSocket.bind(('', self.port))
         self.udpSocket.settimeout(1)
 


### PR DESCRIPTION
- Changed tofCam660 UDP interface to allow reuse of same address/port since it's fixed and Linux takes a long time to release it after UdpInterface.close() (ie. self.udpSocket.close() )
- Expect to be able to power cycle the tofCam660 and be able to reconnect immediately over ethernet without have previous connection to fully expire in the OS